### PR TITLE
Add file_open_option to open SHIFT_JIS file

### DIFF
--- a/lib/active_admin_import/importer.rb
+++ b/lib/active_admin_import/importer.rb
@@ -17,7 +17,8 @@ module ActiveAdminImport
       :headers_rewrites,
       :batch_size,
       :batch_transaction,
-      :csv_options
+      :csv_options,
+      :file_open_option
     ].freeze
 
     def initialize(resource, model, options)
@@ -68,12 +69,16 @@ module ActiveAdminImport
       headers.values.index(header_key)
     end
 
+    def file_open_option
+      @file_open_option ||= options[:file_open_option]
+    end
+
     protected
 
     def process_file
       lines = []
       batch_size = options[:batch_size].to_i
-      File.open(file.path) do |f|
+      File.open(file.path, file_open_option) do |f|
         # capture headers if not exist
         prepare_headers { CSV.parse(f.readline, @csv_options).first }
         f.each_line do |line|

--- a/lib/active_admin_import/options.rb
+++ b/lib/active_admin_import/options.rb
@@ -4,6 +4,7 @@ module ActiveAdminImport
     VALID_OPTIONS = [
       :back,
       :csv_options,
+      :file_open_option,
       :validate,
       :batch_size,
       :batch_transaction,


### PR DESCRIPTION
Can't open sjis file.
```
ArgumentError - invalid byte sequence in UTF-8:
       	  activesupport (4.2.7.1) lib/active_support/core_ext/object/blank.rb:117:in `blank?'
       	  activesupport (4.2.7.1) lib/active_support/core_ext/object/blank.rb:24:in `present?'
       	  active_admin_import/lib/active_admin_import/importer.rb:85:in `block (2 levels) in process_file'
       	  active_admin_import/lib/active_admin_import/importer.rb:84:in `block in process_file'
       	  active_admin_import/lib/active_admin_import/importer.rb:81:in `process_file'
       	  active_admin_import/lib/active_admin_import/importer.rb:46:in `import'
       	  active_admin_import/lib/active_admin_import/dsl.rb:88:in `block in active_admin_import'
       	  actionpack (4.2.7.1) lib/action_controller/metal/implicit_render.rb:4:in `send_action'
       	  actionpack (4.2.7.1) lib/abstract_controller/base.rb:198:in `process_action'
       	  actionpack (4.2.7.1) lib/action_controller/metal/rendering.rb:10:in `process_action'
       	  actionpack (4.2.7.1) lib/abstract_controller/callbacks.rb:20:in `block in process_action'
       	  activesupport (4.2.7.1) lib/active_support/callbacks.rb:117:in `call'
       	  activesupport (4.2.7.1) lib/active_support/callbacks.rb:555:in `block (2 levels) in compile'
       	  activesupport (4.2.7.1) lib/active_support/callbacks.rb:505:in `call'
       	  activesupport (4.2.7.1) lib/active_support/callbacks.rb:92:in `__run_callbacks__'
       	  activesupport (4.2.7.1) lib/active_support/callbacks.rb:778:in `_run_process_action_callbacks'
       	  activesupport (4.2.7.1) lib/active_support/callbacks.rb:81:in `run_callbacks'
...
```
```ruby
active_admin_import file_open_option: 'r:Shift_JIS:UTF-8'
```